### PR TITLE
uartmode script kill_all function refactor

### DIFF
--- a/uartmode
+++ b/uartmode
@@ -2,9 +2,10 @@
 
 kill_all() {
 	rm -f /tmp/uartmode* /tmp/ML_BAUD
-	fuser -k -TERM /dev/ttyS1
-	sleep 0.1
-	fuser -k -KILL /dev/ttyS1
+	if fuser -k -TERM /dev/ttyS1 2>/dev/null; then
+		sleep 0.1
+		fuser -k -KILL /dev/ttyS1 2>/dev/null
+	fi
 }
 
 conn_speed=115200


### PR DESCRIPTION
One day when configuring UART options in the OSD with AO486 I noticed that `pppd` never exits even when another uart option was selected.

With further investigation and manually configuring `pppd` in a ssh session. I discovered that contrary what its documentation might suggest `pppd` doesn’t always respond to SIGHUP, SIGINT or SIGTERM and the only way to get it to relinquish control of `/dev/ttyS1` was to send SIGKILL.

Regardless of what caused `pppd` to behave this way `uartmode` should ensure that `/dev/ttyS1` has no other process accessing it before switching mode.

This PR modifies the `kill_all()` function to send SIGTERM only to processes that have `/dev/ttyS1` open. If any of these processes haven't closed their connection to `/dev/ttyS1` 100ms after SIGTERM was sent to them then SIGKILL is sent to force any remaining process to die ensuring `/dev/ttyS1` is uncontested for the next process.

Sending SIGKILL to processes this way is safe because it’s only sent to processes that still have `/dev/ttyS1` open. This also means processes of `agetty`,`fluidsynth`, `login` etc that aren’t touching `/dev/ttyS1` are left alone while other processes that the previous implementation was unaware of  that are accessing `/dev/ttyS1` are still terminated or killed.