### PR TITLE
PPPD respawn logic

### DIFF
--- a/uartmode
+++ b/uartmode
@@ -43,10 +43,9 @@ if [ "$1" == "1" ]; then
 					echo 1 > /proc/sys/net/ipv4/ip_forward
 					taskset 1 pppd $conn_speed file /tmp/ppp_options
 					status=$?
-					if [ $status -gt 1 ]; then
-						echo "pppd exited on error $status"
-						exit 0
-					fi
+					case $status in
+						1|2|3|4|6|7|9|137) echo "pppd exited with fatal error $status"; exit 0;;
+					esac
 				else
 					echo "skip pppd"
 					exit 0

--- a/uartmode
+++ b/uartmode
@@ -42,6 +42,11 @@ if [ "$1" == "1" ]; then
 
 					echo 1 > /proc/sys/net/ipv4/ip_forward
 					taskset 1 pppd $conn_speed file /tmp/ppp_options
+					status=$?
+					if [ $status -gt 1 ]; then
+						echo "pppd exited on error $status"
+						exit 0
+					fi
 				else
 					echo "skip pppd"
 					exit 0


### PR DESCRIPTION
This PR checks the return value of `pppd` after it exits and dosen't respawn it if the error in question would result in a failing loop that would just be burning CPU and SDcard write cycles.

These errors include:
1: An immediately fatal error of some kind occurred
2: An error was detected in processing the options given (in `ppp_options`, this one is very likely if someone makes a typo in their config)
3: `pppd` is not root
4: The kernel does not support PPP (might happen on someones custom kernel built with CONFIG_PPP unset)
6: Serial port couldn't be locked
7: Serial port couldn't be opened
9: The pty command couldn't be run
137: Someone or something sent SIGKILL to `pppd` (so they probably don't want it to respawn)

The other 13 error codes `pppd` could return are part of normal operation (modem hangup, idle connection timeout, authenication failure etc...). In these cases, `pppd` is still respawned.